### PR TITLE
Convert some plain examples to assert_eq! in doctests

### DIFF
--- a/src/policies/access_policy.rs
+++ b/src/policies/access_policy.rs
@@ -78,24 +78,17 @@ impl AccessPolicy {
     }
 
     /// Generate an access policy from a map of policy access names to policy
-    /// attributes e.g.
-    /// ```json
-    /// {
-    ///     "Department": ["HR","FIN"],
-    ///     "Level": ["level_2"],
-    /// }
-    /// ```
-    /// The axes are ORed between each others while the attributes
+    /// attributes. The axes are ORed between each others while the attributes
     /// of each axis are ANDed.
     ///
     /// ```
     /// use std::collections::HashMap;
     /// use cover_crypt::policies::{AccessPolicy, ap};
     ///
-    /// let axes = HashMap::from([
-    ///     ("Department".to_owned(), vec!["HR".to_owned(),"FIN".to_owned()]),
-    ///     ("Level".to_owned(), vec!["level_2".to_owned()]),
-    /// ]);
+    /// let axes = serde_json::from_str(r#"{
+    ///     "Department": ["HR","FIN"],
+    ///     "Level": ["level_2"]
+    /// }"#).unwrap();
     ///
     /// let access_policy = AccessPolicy::from_axes(&axes);
     /// assert_eq!(
@@ -252,7 +245,7 @@ impl AccessPolicy {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use cover_crypt::policies::{AccessPolicy, ap};
     ///
     /// let boolean_expression = "(Department::HR || Department::RnD) && Level::level_2";
@@ -411,14 +404,14 @@ impl From<Attribute> for AccessPolicy {
 /// Create an axis policy from a simple attribute
 ///
 /// Shorthand for
-/// ```rust
+/// ```
 /// let axis="axis_name";
 /// let attribute_name="attribute_name";
 /// let access_policy = cover_crypt::policies::AccessPolicy::new(axis, attribute_name);
 /// ```
 ///
 /// Used to easily build access policies programmatically
-/// ```rust
+/// ```
 /// use cover_crypt::policies::ap;
 /// let access_policy =
 ///     ap("Security Level", "level 4") & (ap("Department", "MKG") | ap("Department", "FIN"));


### PR DESCRIPTION
Do not know if it was wanted, but some examples put the results inside plain english sentences. Converting them in `assert_eq!()` allows us to test these assertions.

Some questions:
- maybe plain english is more readable and we should add them back (but with the risk of a divergence between the two information)
- do you prefer the `.unwrap()` on the `let` binding or inside the `assert_eq!()` (I personally prefer the `assert_eq!()` because it's not the part copy/pasted by the user…). Maybe one day Rust will allow `?` in doctests.
- it may be more readable to use `serde` to parse the JSON (these `.to_owned()` are really ugly) but it imply adding another dependency to the example? And hiding the type of the function's parameter… Don't know if I prefer it… (see difference below)

![Without Serde](https://user-images.githubusercontent.com/1770543/170713220-8b78d42c-93c5-4683-8a67-823678516033.png)

![With Serde](https://user-images.githubusercontent.com/1770543/170712967-18c0cae1-c665-4f48-8aca-1b82acaf5fcf.png)
