### PR TITLE
fix!: naming and serialization

### DIFF
--- a/src/interfaces/wasm_bindgen/hybrid_cc_aes.rs
+++ b/src/interfaces/wasm_bindgen/hybrid_cc_aes.rs
@@ -116,7 +116,7 @@ pub fn webassembly_decrypt_hybrid_header(
 pub fn webassembly_encrypt_symmetric_block(
     symmetric_key_bytes: Uint8Array,
     plaintext_bytes: Uint8Array,
-    associated_data: Uint8Array,
+    authenticated_data: Uint8Array,
 ) -> Result<Uint8Array, JsValue> {
     //
     // Check `plaintext_bytes` input parameter
@@ -131,14 +131,17 @@ pub fn webassembly_encrypt_symmetric_block(
 
     //
     // Encrypt block
-    let associated_data = associated_data.to_vec();
-    let ad = if associated_data.is_empty() {
+    let authenticated_data = if authenticated_data.is_null() {
         None
     } else {
-        Some(associated_data.as_slice())
+        Some(authenticated_data.to_vec())
     };
     let ciphertext = CoverCryptX25519Aes256::default()
-        .encrypt(&symmetric_key, &plaintext_bytes.to_vec(), ad)
+        .encrypt(
+            &symmetric_key,
+            &plaintext_bytes.to_vec(),
+            authenticated_data.as_deref(),
+        )
         .map_err(|e| JsValue::from_str(&format!("Error encrypting block: {e}")))?;
 
     Ok(Uint8Array::from(&ciphertext[..]))

--- a/src/interfaces/wasm_bindgen/hybrid_cc_aes.rs
+++ b/src/interfaces/wasm_bindgen/hybrid_cc_aes.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use abe_policy::AccessPolicy;
 use cosmian_crypto_core::{
-    bytes_ser_de::{Deserializer, Serializable},
+    bytes_ser_de::{Deserializer, Serializable, Serializer},
     symmetric_crypto::SymKey,
     KeyTrait,
 };
@@ -237,13 +237,13 @@ pub fn webassembly_hybrid_encrypt(
         .map_err(|e| JsValue::from_str(&format!("Error encrypting symmetric plaintext: {e}")))?;
 
     // concatenate the two encrypted header and the ciphertext
-    let encrypted_header_bytes = encrypted_header
-        .try_to_bytes()
+    let mut ser = Serializer::new();
+    encrypted_header
+        .write(&mut ser)
         .map_err(|e| JsValue::from_str(&format!("Error serializing encrypted header: {e}")))?;
-    let mut bytes = Vec::<u8>::with_capacity(encrypted_header_bytes.len() + ciphertext.len());
-    bytes.extend_from_slice(&encrypted_header_bytes);
-    bytes.extend_from_slice(&ciphertext);
-    Ok(Uint8Array::from(bytes.as_slice()))
+    ser.write_array(&ciphertext)
+        .map_err(|e| JsValue::from_str(&format!("Error writting ciphertext: {e}")))?;
+    Ok(Uint8Array::from(ser.finalize().as_slice()))
 }
 
 /// Decrypt the DEM ciphertext with the header encapsulated symmetric key,
@@ -260,8 +260,8 @@ pub fn webassembly_hybrid_decrypt(
 ) -> Result<Uint8Array, JsValue> {
     // read encrypted bytes as the concatenation of an encrypted header
     // and a DEM ciphertext
-    let ciphertext = encrypted_bytes.to_vec();
-    let mut de = Deserializer::new(&ciphertext);
+    let encrypted_bytes = encrypted_bytes.to_vec();
+    let mut de = Deserializer::new(&encrypted_bytes);
     // this will read the exact header size
     let header = EncryptedHeader::read(&mut de)
         .map_err(|e| JsValue::from_str(&format!("Error parsing encrypted header: {e}")))?;


### PR DESCRIPTION
- `additional_data` -> `authenticated_data` in `webassembly_encrypt_symmetric_block`
- remove vector size in header serialization

BREAKING CHANGE: breaks WASM interface & header serialization