### PR TITLE
fix: benchmaks

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -3,6 +3,7 @@ use cosmian_cover_crypt::{
     interfaces::statics::{CoverCryptX25519Aes256, EncryptedHeader},
     CoverCrypt, Error,
 };
+#[cfg(feature = "full_bench")]
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use criterion::{criterion_group, criterion_main, Criterion};
 #[cfg(feature = "ffi")]
@@ -40,6 +41,58 @@ fn policy() -> Result<Policy, Error> {
     Ok(policy)
 }
 
+/// Generate access policies up to 5 partitions along with a user access policy
+/// that allows decrypting headers for all these access policies.
+///
+/// Access policies with more than one partition are generated only if
+/// `--features full_bench` is passed.
+fn get_access_policies() -> (AccessPolicy, Vec<AccessPolicy>) {
+    // Access policy with 1 partition
+    #[allow(unused_mut)]
+    let mut access_policies =
+        vec![
+            AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
+                .unwrap(),
+        ];
+
+    #[cfg(feature = "full_bench")]
+    {
+        // Access policy with 2 partition
+        access_policies.push(
+            AccessPolicy::from_boolean_expression(
+                "(Department::FIN || Department::HR) && Security Level::Protected",
+            )
+            .unwrap(),
+        );
+
+        // Access policy with 3 partition
+        access_policies.push(AccessPolicy::from_boolean_expression(
+            "(Department::FIN || Department::HR || Department::MKG) && Security Level::Protected",
+        )
+        .unwrap());
+
+        // Access policy with 4 partition
+        access_policies.push( AccessPolicy::from_boolean_expression(
+                "(Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
+                Level::Protected",
+        )
+            .unwrap());
+
+        // Access policy with 5 partition
+        access_policies.push(AccessPolicy::from_boolean_expression(
+        "((Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
+         Level::Protected) || (Department::HR && Security Level::Top Secret)",
+    )
+    .unwrap());
+    }
+
+    let user_access_policy =
+        AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
+            .unwrap();
+
+    (user_access_policy, access_policies)
+}
+
 /// Generate encrypted header with some additional data
 #[cfg(feature = "ffi")]
 fn generate_encrypted_header(
@@ -51,7 +104,6 @@ fn generate_encrypted_header(
     let policy_access =
         AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Confidential")
             .unwrap();
-
     let (_, ctx) = EncryptedHeader::generate(
         cover_crypt,
         &policy,
@@ -64,309 +116,101 @@ fn generate_encrypted_header(
     ctx
 }
 
+#[cfg(feature = "full_bench")]
 fn bench_serialization(c: &mut Criterion) {
     let policy = policy().expect("cannot generate policy");
-
+    let (user_access_policy, access_policies) = get_access_policies();
     let cover_crypt = CoverCryptX25519Aes256::default();
     let (msk, mpk) = cover_crypt
         .generate_master_keys(&policy)
         .expect("cannot generate master keys");
+    println!("bench header encryption size: ");
+    for (n_partition, access_policy) in access_policies.iter().enumerate() {
+        let (_, encrypted_header) =
+            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, access_policy, None, None)
+                .expect("cannot encrypt header 1");
+        println!(
+            "{} partition(s): {} bytes",
+            n_partition + 1,
+            encrypted_header.try_to_bytes().unwrap().len(),
+        );
+    }
 
-    let user_access_policy =
-        AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
-            .unwrap();
-    let user_decryption_key = cover_crypt
+    let usk = cover_crypt
         .generate_user_secret_key(&msk, &user_access_policy, &policy)
-        .expect("cannot generate user private key");
+        .unwrap();
 
-    // access policy with 1 partition
-    let access_policy_1 =
-        AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
-            .unwrap();
-
-    // access policy with 2 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_2 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR) && Security Level::Protected",
-    )
-    .unwrap();
-
-    // access policy with 3 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_3 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR || Department::MKG) && Security Level::Protected",
-    )
-    .unwrap();
-
-    // access policy with 4 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_4 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
-         Level::Protected",
-    )
-    .unwrap();
-
-    // access policy with 5 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_5 = AccessPolicy::from_boolean_expression(
-        "((Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
-         Level::Protected) || (Department::HR && Security Level::Top Secret)",
-    )
-    .unwrap();
-
-    // get ready ciphertexts for size benchmark
-    let (_, encrypted_header_1) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_1, None, None)
-            .expect("cannot encrypt header 1");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_2) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_2, None, None)
-            .expect("cannot encrypt header 2");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_3) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_3, None, None)
-            .expect("cannot encrypt header 3");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_4) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_4, None, None)
-            .expect("cannot encrypt header 4");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_5) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_5, None, None)
-            .expect("cannot encrypt header 5");
-
-    #[cfg(not(feature = "full_bench"))]
-    print!("bench header encryption size: ");
-    #[cfg(not(feature = "full_bench"))]
-    println!(
-        "1 partition {} bytes\n",
-        encrypted_header_1.try_to_bytes().unwrap().len(),
-    );
-    #[cfg(feature = "full_bench")]
-    println!("bench header encryption size:");
-    #[cfg(feature = "full_bench")]
-    println!(
-        "1 partition: {} bytes\n2 partitions: {} bytes\n3 partitions: {} bytes\n4 partitions: {} \
-         bytes\n5 partitions: {} bytes\n",
-        encrypted_header_1.try_to_bytes().unwrap().len(),
-        encrypted_header_2.try_to_bytes().unwrap().len(),
-        encrypted_header_3.try_to_bytes().unwrap().len(),
-        encrypted_header_4.try_to_bytes().unwrap().len(),
-        encrypted_header_5.try_to_bytes().unwrap().len(),
-    );
-
-    let mut group = c.benchmark_group("key serialization");
-
+    let mut group = c.benchmark_group("Key serialization");
     group.bench_function("MSK", |b| {
         b.iter(|| msk.try_to_bytes().expect("cannot serialize msk"))
     });
-
     group.bench_function("MPK", |b| {
         b.iter(|| mpk.try_to_bytes().expect("cannot serialize mpk"))
     });
-
     group.bench_function("USK", |b| {
-        b.iter(|| {
-            user_decryption_key
-                .try_to_bytes()
-                .expect("cannot serialize usk")
-        })
+        b.iter(|| usk.try_to_bytes().expect("cannot serialize usk"))
     });
 
     // removes borrow checker warning about several mutable reference on `c`
     drop(group);
 
-    let mut group = c.benchmark_group("header serialization");
-
-    group.bench_function("1 partition", |b| {
-        b.iter(|| {
-            encrypted_header_1
-                .try_to_bytes()
-                .expect("cannot serialize header 1")
-        })
-    });
-
-    #[cfg(feature = "full_bench")]
-    group.bench_function("2 partitions", |b| {
-        b.iter(|| {
-            encrypted_header_2
-                .try_to_bytes()
-                .expect("cannot serialize header 2")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("3 partitions", |b| {
-        b.iter(|| {
-            encrypted_header_3
-                .try_to_bytes()
-                .expect("cannot serialize header 3")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("4 partitions", |b| {
-        b.iter(|| {
-            encrypted_header_4
-                .try_to_bytes()
-                .expect("cannot serialize header 4")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("5 partitions", |b| {
-        b.iter(|| {
-            encrypted_header_5
-                .try_to_bytes()
-                .expect("cannot serialize header 5")
-        })
-    });
+    let mut group = c.benchmark_group("Header serialization");
+    for (n_partition, access_policy) in access_policies.iter().enumerate() {
+        let (_, encrypted_header) =
+            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, access_policy, None, None)
+                .expect("cannot encrypt header 1");
+        group.bench_function(&format!("{} partition(s)", n_partition + 1), |b| {
+            b.iter(|| {
+                encrypted_header.try_to_bytes().unwrap_or_else(|_| {
+                    panic!(
+                        "cannot serialize header for {} partition(s)",
+                        n_partition + 1
+                    )
+                })
+            })
+        });
+    }
 }
 
 fn bench_header_encryption(c: &mut Criterion) {
     let policy = policy().expect("cannot generate policy");
-
+    let (_, access_policies) = get_access_policies();
     let cover_crypt = CoverCryptX25519Aes256::default();
-    let (_msk, mpk) = cover_crypt
+    let (_, mpk) = cover_crypt
         .generate_master_keys(&policy)
         .expect("cannot generate master keys");
 
-    // access policy with 1 partition
-    let access_policy_1 =
-        AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
-            .unwrap();
-
-    // access policy with 2 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_2 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR) && Security Level::Protected",
-    )
-    .unwrap();
-
-    // access policy with 3 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_3 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR || Department::MKG) && Security Level::Protected",
-    )
-    .unwrap();
-
-    // access policy with 4 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_4 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
-         Level::Protected",
-    )
-    .unwrap();
-
-    // access policy with 5 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_5 = AccessPolicy::from_boolean_expression(
-        "((Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
-         Level::Protected) || (Department::HR && Security Level::Top Secret)",
-    )
-    .unwrap();
-
-    // get ready ciphertexts for size benchmark
-    let (_, encrypted_header_1) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_1, None, None)
-            .expect("cannot encrypt header 1");
+    let mut group = c.benchmark_group("Header encryption");
+    for (n_partition, access_policy) in access_policies.iter().enumerate() {
+        group.bench_function(&format!("{} partition(s), 1 access", n_partition + 1), |b| {
+            b.iter(|| {
+                EncryptedHeader::generate(&cover_crypt, &policy, &mpk, access_policy, None, None)
+                    .unwrap_or_else(|_| {
+                        panic!("cannot encrypt header for {} partition(s)", n_partition + 1)
+                    })
+            })
+        });
+    }
 
     #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_2) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_2, None, None)
-            .expect("cannot encrypt header 2");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_3) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_3, None, None)
-            .expect("cannot encrypt header 3");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_4) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_4, None, None)
-            .expect("cannot encrypt header 4");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_5) =
-        EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_5, None, None)
-            .expect("cannot encrypt header 5");
-
-    #[cfg(not(feature = "full_bench"))]
-    print!("bench header encryption size: ");
-    #[cfg(not(feature = "full_bench"))]
-    println!(
-        "1 partition {} bytes\n",
-        encrypted_header_1.try_to_bytes().unwrap().len(),
-    );
-    #[cfg(feature = "full_bench")]
-    println!("bench header encryption size:");
-    #[cfg(feature = "full_bench")]
-    println!(
-        "1 partition: {} bytes\n2 partitions: {} bytes\n3 partitions: {} bytes\n4 partitions: {} \
-         bytes\n5 partitions: {} bytes\n",
-        encrypted_header_1.try_to_bytes().unwrap().len(),
-        encrypted_header_2.try_to_bytes().unwrap().len(),
-        encrypted_header_3.try_to_bytes().unwrap().len(),
-        encrypted_header_4.try_to_bytes().unwrap().len(),
-        encrypted_header_5.try_to_bytes().unwrap().len(),
-    );
-
-    let mut group = c.benchmark_group("header encryption");
-    group.bench_function("1 partition", |b| {
-        b.iter(|| {
-            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_1, None, None)
+    {
+        // Do not bench encryption with metadata if a full benchmark is not running
+        let additional_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let authenticated_data = vec![10, 11, 12, 13, 14];
+        group.bench_function("1 partition, 1 access + metadata", |b| {
+            b.iter(|| {
+                EncryptedHeader::generate(
+                    &cover_crypt,
+                    &policy,
+                    &mpk,
+                    &access_policies[0],
+                    Some(&additional_data),
+                    Some(&authenticated_data),
+                )
                 .expect("cannot encrypt header 1")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("2 partitions", |b| {
-        b.iter(|| {
-            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_2, None, None)
-                .expect("cannot encrypt header 2")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("3 partitions", |b| {
-        b.iter(|| {
-            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_3, None, None)
-                .expect("cannot encrypt header 3")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("4 partitions", |b| {
-        b.iter(|| {
-            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_4, None, None)
-                .expect("cannot encrypt header 4")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    group.bench_function("5 partitions", |b| {
-        b.iter(|| {
-            EncryptedHeader::generate(&cover_crypt, &policy, &mpk, &access_policy_5, None, None)
-                .expect("cannot encrypt header 5")
-        })
-    });
-
-    #[cfg(feature = "full_bench")]
-    let additional_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-    #[cfg(feature = "full_bench")]
-    let authenticated_data = vec![10, 11, 12, 13, 14];
-
-    #[cfg(feature = "full_bench")]
-    group.bench_function("speed with additional data", |b| {
-        b.iter(|| {
-            EncryptedHeader::generate(
-                &cover_crypt,
-                &policy,
-                &mpk,
-                &access_policy_1,
-                Some(&additional_data),
-                Some(&authenticated_data),
-            )
-            .expect("cannot encrypt header 1")
-        })
-    });
+            })
+        });
+    }
 }
 
 #[cfg(feature = "ffi")]
@@ -517,194 +361,74 @@ unsafe fn unwrap_ffi_error(val: i32) -> Result<(), Error> {
 fn bench_header_decryption(c: &mut Criterion) {
     let policy = policy().expect("cannot generate policy");
     let authenticated_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-
+    let (user_access_policy, access_policies) = get_access_policies();
     let cover_crypt = CoverCryptX25519Aes256::default();
     let (msk, mpk) = cover_crypt
         .generate_master_keys(&policy)
         .expect("cannot generate master keys");
-
-    // Access policy with 1 partition
-    let access_policy_1 =
-        AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
-            .unwrap();
-
-    // Access policy with 2 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_2 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR) && Security Level::Protected",
-    )
-    .unwrap();
-
-    // Access policy with 3 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_3 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR || Department::MKG) && Security Level::Protected",
-    )
-    .unwrap();
-
-    // Access policy with 4 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_4 = AccessPolicy::from_boolean_expression(
-        "(Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
-         Level::Protected",
-    )
-    .unwrap();
-
-    // Access policy with 5 partition
-    #[cfg(feature = "full_bench")]
-    let access_policy_5 = AccessPolicy::from_boolean_expression(
-        "((Department::FIN || Department::HR || Department::MKG || Department::R&D) && Security \
-         Level::Protected) || (Department::HR && Security Level::Top Secret)",
-    )
-    .unwrap();
-
-    // Get ready ciphertexts for size benchmark
-    let (_, encrypted_header_1) = EncryptedHeader::generate(
-        &cover_crypt,
-        &policy,
-        &mpk,
-        &access_policy_1,
-        None,
-        Some(&authenticated_data),
-    )
-    .expect("cannot encrypt header 1");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_2) = EncryptedHeader::generate(
-        &cover_crypt,
-        &policy,
-        &mpk,
-        &access_policy_2,
-        None,
-        Some(&authenticated_data),
-    )
-    .expect("cannot encrypt header 2");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_3) = EncryptedHeader::generate(
-        &cover_crypt,
-        &policy,
-        &mpk,
-        &access_policy_3,
-        None,
-        Some(&authenticated_data),
-    )
-    .expect("cannot encrypt header 3");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_4) = EncryptedHeader::generate(
-        &cover_crypt,
-        &policy,
-        &mpk,
-        &access_policy_4,
-        None,
-        Some(&authenticated_data),
-    )
-    .expect("cannot encrypt header 4");
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_5) = EncryptedHeader::generate(
-        &cover_crypt,
-        &policy,
-        &mpk,
-        &access_policy_5,
-        None,
-        Some(&authenticated_data),
-    )
-    .expect("cannot encrypt header 5");
-
-    #[cfg(feature = "full_bench")]
-    let additional_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-
-    #[cfg(feature = "full_bench")]
-    let (_, encrypted_header_with_metadata) = EncryptedHeader::generate(
-        &cover_crypt,
-        &policy,
-        &mpk,
-        &access_policy_1,
-        Some(&additional_data),
-        Some(&authenticated_data),
-    )
-    .expect("cannot encrypt header with metadata");
-
-    let user_access_policy =
-        AccessPolicy::from_boolean_expression("Department::FIN && Security Level::Protected")
-            .unwrap();
     let user_decryption_key = cover_crypt
         .generate_user_secret_key(&msk, &user_access_policy, &policy)
         .expect("cannot generate user private key");
 
-    c.bench_function("Header decryption/1 partition, 1 access", |b| {
-        b.iter(|| {
-            encrypted_header_1
-                .decrypt(
-                    &cover_crypt,
-                    &user_decryption_key,
-                    Some(&authenticated_data),
-                )
-                .expect("cannot decrypt hybrid header")
-        })
-    });
+    let mut group = c.benchmark_group("Header encryption + decryption");
+    for (n_partition, access_policy) in access_policies.iter().enumerate() {
+        group.bench_function(
+            &format!(
+                "{} partition(s), 1 access",
+                n_partition + 1
+            ),
+            |b| {
+                b.iter(|| {
+                    let (_, encrypted_header) = EncryptedHeader::generate(
+                        &cover_crypt,
+                        &policy,
+                        &mpk,
+                        access_policy,
+                        None,
+                        Some(&authenticated_data),
+                    )
+                    .unwrap_or_else(|_| {
+                        panic!("cannot encrypt header for {} partition(s)", n_partition + 1)
+                    });
+                    encrypted_header
+                        .decrypt(
+                            &cover_crypt,
+                            &user_decryption_key,
+                            Some(&authenticated_data),
+                        )
+                        .unwrap_or_else(|_| {
+                            panic!("cannot decrypt header for {} partition(s)", n_partition + 1)
+                        });
+                })
+            },
+        );
+    }
+
     #[cfg(feature = "full_bench")]
-    c.bench_function("Header decryption/2 partition, 1 access", |b| {
-        b.iter(|| {
-            encrypted_header_2
-                .decrypt(
+    {
+        // Do not bench decryption with metadata if a full benchmark is not running
+        let additional_data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        group.bench_function("1 partition, 1 access + metadata", |b| {
+            b.iter(|| {
+                let (_, encrypted_header) = EncryptedHeader::generate(
                     &cover_crypt,
-                    &user_decryption_key,
+                    &policy,
+                    &mpk,
+                    &access_policies[0],
+                    Some(&additional_data),
                     Some(&authenticated_data),
                 )
-                .expect("cannot decrypt hybrid header")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    c.bench_function("Header decryption/3 partition, 1 access", |b| {
-        b.iter(|| {
-            encrypted_header_3
-                .decrypt(
-                    &cover_crypt,
-                    &user_decryption_key,
-                    Some(&authenticated_data),
-                )
-                .expect("cannot decrypt hybrid header")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    c.bench_function("Header decryption/4 partition, 1 access", |b| {
-        b.iter(|| {
-            encrypted_header_4
-                .decrypt(
-                    &cover_crypt,
-                    &user_decryption_key,
-                    Some(&authenticated_data),
-                )
-                .expect("cannot decrypt hybrid header")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    c.bench_function("Header decryption/5 partition, 1 access", |b| {
-        b.iter(|| {
-            encrypted_header_5
-                .decrypt(
-                    &cover_crypt,
-                    &user_decryption_key,
-                    Some(&authenticated_data),
-                )
-                .expect("cannot decrypt hybrid header")
-        })
-    });
-    #[cfg(feature = "full_bench")]
-    c.bench_function("Header decryption/1 partition, 1 access", |b| {
-        b.iter(|| {
-            encrypted_header_with_metadata
-                .decrypt(
-                    &cover_crypt,
-                    &user_decryption_key,
-                    Some(&authenticated_data),
-                )
-                .expect("cannot decrypt hybrid header")
-        })
-    });
+                .expect("cannot encrypt header with metadata");
+                encrypted_header
+                    .decrypt(
+                        &cover_crypt,
+                        &user_decryption_key,
+                        Some(&authenticated_data),
+                    )
+                    .expect("cannot decrypt hybrid header")
+            })
+        });
+    }
 }
 
 #[cfg(feature = "ffi")]
@@ -836,6 +560,7 @@ criterion_group!(
         bench_header_decryption
 );
 
+#[cfg(feature = "full_bench")]
 criterion_group!(
     name = benches_serialization;
     config = Criterion::default().sample_size(5000);
@@ -853,8 +578,14 @@ criterion_group!(
         bench_ffi_header_decryption_using_cache
 );
 
-#[cfg(feature = "ffi")]
+#[cfg(all(feature = "ffi", feature = "full_bench"))]
 criterion_main!(benches, benches_serialization, benches_ffi);
 
-#[cfg(not(feature = "ffi"))]
+#[cfg(all(feature = "ffi", not(feature = "full_bench")))]
+criterion_main!(benches, benches_ffi);
+
+#[cfg(all(not(feature = "ffi"), feature = "full_bench"))]
 criterion_main!(benches, benches_serialization);
+
+#[cfg(all(not(feature = "ffi"), not(feature = "full_bench")))]
+criterion_main!(benches);

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -182,14 +182,24 @@ fn bench_header_encryption(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("Header encryption");
     for (n_partition, access_policy) in access_policies.iter().enumerate() {
-        group.bench_function(&format!("{} partition(s), 1 access", n_partition + 1), |b| {
-            b.iter(|| {
-                EncryptedHeader::generate(&cover_crypt, &policy, &mpk, access_policy, None, None)
+        group.bench_function(
+            &format!("{} partition(s), 1 access", n_partition + 1),
+            |b| {
+                b.iter(|| {
+                    EncryptedHeader::generate(
+                        &cover_crypt,
+                        &policy,
+                        &mpk,
+                        access_policy,
+                        None,
+                        None,
+                    )
                     .unwrap_or_else(|_| {
                         panic!("cannot encrypt header for {} partition(s)", n_partition + 1)
                     })
-            })
-        });
+                })
+            },
+        );
     }
 
     #[cfg(feature = "full_bench")]
@@ -373,10 +383,7 @@ fn bench_header_decryption(c: &mut Criterion) {
     let mut group = c.benchmark_group("Header encryption + decryption");
     for (n_partition, access_policy) in access_policies.iter().enumerate() {
         group.bench_function(
-            &format!(
-                "{} partition(s), 1 access",
-                n_partition + 1
-            ),
+            &format!("{} partition(s), 1 access", n_partition + 1),
             |b| {
                 b.iter(|| {
                     let (_, encrypted_header) = EncryptedHeader::generate(


### PR DESCRIPTION
Decryption benchmarks was giving unreliable results due to the EAKEM. Since both the encrypted header and the user secret key were generated before benchmarking, the order in the hashmap/hashset was unique per benchmark. Hence the decryption iteration for which the key was correctly decapsulated was constant per benchmark.

Bonus: make benchmark logic cleaner by grouping access policies in a vector.