### PR TITLE
fix: benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,8 +204,8 @@ benchmarks:
   before_script:
     - apt update && apt install -y gnuplot
   script:
-    - cargo bench --features full_bench
     - cargo bench --features full_bench,hybridized_bench
+    - cargo bench --features full_bench
   when: manual
 
 #


### PR DESCRIPTION
Two new features are used:
- `full_bench`: different encapsulation sizes and user secret keys;
- `hybridized_bench`: use the hybridized version of CoverCrypt (the default is the classic version).