### PR TITLE
simplifies the implementation of `PkeAc` for Covercrypt

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -80,7 +80,7 @@ pub trait PkeAc<const KEY_LENGTH: usize, E: AE<KEY_LENGTH>> {
     /// decrypt this ciphertext.
     fn decrypt(
         &self,
-        usk: &Self::DecryptionKey,
+        dk: &Self::DecryptionKey,
         ctx: &Self::Ciphertext,
     ) -> Result<Option<Zeroizing<Vec<u8>>>, Self::Error>;
 }


### PR DESCRIPTION
Small code improvement for the PKE-AC implementation. The new version is really straightforward. The main improvement was to use the `Secret::derive` function to derive the DEM key from the encapsulated secret instead of re-implementing it twice.